### PR TITLE
Improve text readability and hide buttons after trostpreis

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,7 +152,8 @@ arcs.append("text")
        d.angle=(d.startAngle+d.endAngle)/2;
        var radius=r*0.6;
        var angle=d.angle*180/Math.PI-90;
-       return "rotate("+angle+")translate("+radius+")rotate("+(-angle)+")";
+       var flip=(angle>-90 && angle<90)?180:0;
+       return "rotate("+angle+")translate("+radius+")rotate("+flip+")";
     })
     .attr("text-anchor","middle")
     .style("font-size","16px")

--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@ body{
   margin-top:20px;
   text-align:center;
 }
-#question h1{font-size:1.3rem;font-weight:bold;margin:0;max-width:90vw;word-wrap:break-word;}
+#question h1{font-size:1.3rem;font-weight:bold;margin:0;max-width:90vw;overflow-wrap:anywhere;}
 #spinBtn{
   margin-top:20px;
   padding:1rem 2rem;
@@ -110,14 +110,14 @@ var padding={top:20,right:20,bottom:20,left:20},
     color=d3.scale.category20();
 const TROST_INDEX=7;
 var data = [
- {label:"100 € Ikea Guthaben", value:1, question:"Knapp daneben! Dein Wohnzimmer muss noch warten 😅"},
+ {label:"100€ Ikea Gutschein", value:1, question:"Knapp daneben! Dein Wohnzimmer muss noch warten 😅"},
  {label:"Europapark Ticket", value:1, question:"Leider kein Adrenalinkick – aber vielleicht beim nächsten Dreh 🎢"},
  {label:"Fast der Hauptgewinn", value:1, question:"Die Menge tobt – doch das richtige Feld war nur einen Hauch entfernt..."},
  {label:"Nochmal drehen?", value:1, question:"Der Moderator gönnt dir eine Extra-Chance 🔄"},
  {label:"Niete", value:1, question:"Immerhin kein Totalverlust, dreh nochmal!"},
- {label:"Therme Erding Gutschein für 2", value:1, question:"Heiße Quellen bleiben heute kalt 💦"},
- {label:"⭐ Hauptpreis: Staubsaugerroboter AI", value:1, question:"Oh nein! Knapp am ultimativen Gewinn vorbeigeschrammt 🤖"},
- {label:"🎁 Trostpreis: Eis essen gehen", value:1, question:"Happy Birthday Sammy! Dein echtes Geschenk ist ein Eis-Date 🍦🎉"}
+ {label:"Therme Erding für Zwei", value:1, question:"Heiße Quellen bleiben heute kalt 💦"},
+ {label:"⭐ Staubsaugerroboter", value:1, question:"Oh nein! Knapp am ultimativen Gewinn vorbeigeschrammt 🤖"},
+ {label:"🎁 Eis-Date", value:1, question:"Happy Birthday Sammy! Dein echtes Geschenk ist ein Eis-Date 🍦🎉"}
 ];
 
 
@@ -147,13 +147,18 @@ arcs.append("path")
     .attr("d",arc);
 
 arcs.append("text")
-    .attr("transform",function(d){
+    .attr("transform",function(d,i){
        d.innerRadius=0; d.outerRadius=r;
        d.angle=(d.startAngle+d.endAngle)/2;
-       return "rotate("+(d.angle*180/Math.PI-90)+")translate("+(d.outerRadius-40)+")";
+       var l=data[i].label.length;
+       var radius=d.outerRadius-40;
+       if(l<10) radius=d.outerRadius-30;
+       else if(l>20) radius=d.outerRadius-60;
+       return "rotate("+(d.angle*180/Math.PI-90)+")translate("+radius+")";
     })
-    .attr("text-anchor","end")
+    .attr("text-anchor","middle")
     .style("font-size","12px")
+    .style("dominant-baseline","middle")
     .text(function(d,i){return data[i].label;});
 
 svg.append("g")

--- a/index.html
+++ b/index.html
@@ -151,7 +151,9 @@ arcs.append("text")
        d.innerRadius=0; d.outerRadius=r;
        d.angle=(d.startAngle+d.endAngle)/2;
        var radius=r*0.6;
-       return "rotate("+(d.angle*180/Math.PI-90)+")translate("+radius+")rotate(180)";
+       var angle=d.angle*180/Math.PI-90;
+       var flip=d.angle>Math.PI?180:0;
+       return "rotate("+angle+")translate("+radius+")rotate("+flip+")";
     })
     .attr("text-anchor","middle")
     .style("font-size","16px")
@@ -215,10 +217,14 @@ function spin(){
            clearInterval(tickTimer);
            oldrotation=rotation;
            d3.select("#question h1").text(data[picked1].question);
-           overlay.style.display="block";
-           overlay.textContent=Math.random()>0.5?"Zweite Chance!":"Super-Spin!";
-           ooh();
-           setTimeout(phase2,800+Math.random()*700);
+           if(picked1===3 || picked1===4){
+               overlay.style.display="block";
+               overlay.textContent=Math.random()>0.5?"Zweite Chance!":"Super-Spin!";
+               ooh();
+               setTimeout(function(){overlay.style.display="none"; phase2();},800+Math.random()*700);
+           }else{
+               setTimeout(phase2,800+Math.random()*700);
+           }
        });
 }
 

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Wheel of Fortune</title>
 <style>
-html,body{margin:0;height:100%;overflow:hidden;}
+html,body{margin:0;height:100%;overflow-x:hidden;overflow-y:auto;}
 body{
   display:flex;
   justify-content:center;
@@ -44,7 +44,7 @@ body{
   margin-top:20px;
   text-align:center;
 }
-#question h1{font-size:1.3rem;font-weight:bold;margin:0;}
+#question h1{font-size:1.3rem;font-weight:bold;margin:0;max-width:90vw;word-wrap:break-word;}
 #spinBtn{
   margin-top:20px;
   padding:1rem 2rem;
@@ -82,16 +82,6 @@ body{
   text-align:center;
   font-size:2rem;
 }
-#gift{
-  display:none;
-  margin-top:15px;
-  padding:1rem;
-  font-size:1rem;
-  background:linear-gradient(#ffd700,#b8860b);
-  border:none;
-  border-radius:8px;
-  cursor:pointer;
-}
 @media(max-width:400px){
   #title{font-size:1.2rem;}
   #question h1{font-size:1rem;}
@@ -106,7 +96,6 @@ body{
 <div id="question" aria-live="polite"><h1></h1></div>
 <div id="overlay"></div>
 <button id="spinBtn" aria-label="Rad drehen">DREHEN</button>
-<button id="gift">Geschenk öffnen</button>
 <script src="https://d3js.org/d3.v3.min.js" charset="utf-8"></script>
 <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.6.0/dist/confetti.browser.min.js"></script>
 <script>
@@ -161,9 +150,10 @@ arcs.append("text")
     .attr("transform",function(d){
        d.innerRadius=0; d.outerRadius=r;
        d.angle=(d.startAngle+d.endAngle)/2;
-       return "rotate("+(d.angle*180/Math.PI-90)+")translate("+(d.outerRadius-10)+")";
+       return "rotate("+(d.angle*180/Math.PI-90)+")translate("+(d.outerRadius-40)+")";
     })
     .attr("text-anchor","end")
+    .style("font-size","12px")
     .text(function(d,i){return data[i].label;});
 
 svg.append("g")
@@ -174,7 +164,6 @@ svg.append("g")
 
 var spinBtn=document.getElementById("spinBtn");
 var overlay=document.getElementById("overlay");
-var giftBtn=document.getElementById("gift");
 var muteBtn=document.getElementById("mute");
 var muted=false;
 
@@ -261,8 +250,7 @@ function phase2(){
            d3.select("#question h1").text(data[picked2].question);
            try{confetti({particleCount:150,spread:70,origin:{y:0.6}});}catch(e){}
            applause();
-           giftBtn.style.display="block";
-           spinBtn.disabled=false;
+           spinBtn.remove();
        });
 }
 

--- a/index.html
+++ b/index.html
@@ -152,8 +152,7 @@ arcs.append("text")
        d.angle=(d.startAngle+d.endAngle)/2;
        var radius=r*0.6;
        var angle=d.angle*180/Math.PI-90;
-       var flip=d.angle>Math.PI?180:0;
-       return "rotate("+angle+")translate("+radius+")rotate("+flip+")";
+       return "rotate("+angle+")translate("+radius+")rotate("+(-angle)+")";
     })
     .attr("text-anchor","middle")
     .style("font-size","16px")

--- a/index.html
+++ b/index.html
@@ -112,7 +112,7 @@ const TROST_INDEX=7;
 var data = [
  {label:"100€ Ikea Gutschein", value:1, question:"Knapp daneben! Dein Wohnzimmer muss noch warten 😅"},
  {label:"Europapark Ticket", value:1, question:"Leider kein Adrenalinkick – aber vielleicht beim nächsten Dreh 🎢"},
- {label:"Fast der Hauptgewinn", value:1, question:"Die Menge tobt – doch das richtige Feld war nur einen Hauch entfernt..."},
+ {label:"Beinahe Jackpot", value:1, question:"Die Menge tobt – doch das richtige Feld war nur einen Hauch entfernt..."},
  {label:"Nochmal drehen?", value:1, question:"Der Moderator gönnt dir eine Extra-Chance 🔄"},
  {label:"Niete", value:1, question:"Immerhin kein Totalverlust, dreh nochmal!"},
  {label:"Therme Erding für Zwei", value:1, question:"Heiße Quellen bleiben heute kalt 💦"},
@@ -150,13 +150,10 @@ arcs.append("text")
     .attr("transform",function(d,i){
        d.innerRadius=0; d.outerRadius=r;
        d.angle=(d.startAngle+d.endAngle)/2;
-       var l=data[i].label.length;
-       var radius=d.outerRadius-40;
-       if(l<10) radius=d.outerRadius-30;
-       else if(l>20) radius=d.outerRadius-60;
+       var radius=d.outerRadius-10;
        return "rotate("+(d.angle*180/Math.PI-90)+")translate("+radius+")";
     })
-    .attr("text-anchor","middle")
+    .attr("text-anchor","end")
     .style("font-size","12px")
     .style("dominant-baseline","middle")
     .text(function(d,i){return data[i].label;});
@@ -217,12 +214,12 @@ function spin(){
      picked1=Math.floor(Math.random()*data.length);
    }while(picked1===TROST_INDEX || picked1===6);
 
-   var turns1=3+Math.floor(Math.random()*2);
+   var turns1=5+Math.floor(Math.random()*3);
    rotation=turns1*360 - picked1*ps;
    rotation += 90 - ps/2;
 
    vis.transition()
-       .duration(4000)
+       .duration(5000)
        .attrTween("transform",rotTween)
        .each("start",function(){tickTimer=setInterval(tick,60);})
        .each("end",function(){
@@ -241,11 +238,11 @@ function phase2(){
    startDrum();
    var ps=360/data.length;
    var picked2=TROST_INDEX;
-   var turns2=2+Math.floor(Math.random()*2);
+   var turns2=4+Math.floor(Math.random()*3);
    rotation=oldrotation + turns2*360 + (picked1 - picked2)*ps;
 
    vis.transition()
-       .duration(5000)
+       .duration(6000)
        .attrTween("transform",rotTween)
        .each("start",function(){tickTimer=setInterval(tick,60);})
        .each("end",function(){

--- a/index.html
+++ b/index.html
@@ -110,13 +110,13 @@ var padding={top:20,right:20,bottom:20,left:20},
     color=d3.scale.category20();
 const TROST_INDEX=7;
 var data = [
- {label:"100€ Ikea Gutschein", value:1, question:"Knapp daneben! Dein Wohnzimmer muss noch warten 😅"},
- {label:"Europapark Ticket", value:1, question:"Leider kein Adrenalinkick – aber vielleicht beim nächsten Dreh 🎢"},
- {label:"Beinahe Jackpot", value:1, question:"Die Menge tobt – doch das richtige Feld war nur einen Hauch entfernt..."},
- {label:"Nochmal drehen?", value:1, question:"Der Moderator gönnt dir eine Extra-Chance 🔄"},
- {label:"Niete", value:1, question:"Immerhin kein Totalverlust, dreh nochmal!"},
- {label:"Therme Erding für Zwei", value:1, question:"Heiße Quellen bleiben heute kalt 💦"},
- {label:"⭐ Staubsaugerroboter", value:1, question:"Oh nein! Knapp am ultimativen Gewinn vorbeigeschrammt 🤖"},
+ {label:"🛍️ 100€ Ikea", value:1, question:"Knapp daneben! Dein Wohnzimmer muss noch warten 😅"},
+ {label:"🎢 Europapark", value:1, question:"Leider kein Adrenalinkick – aber vielleicht beim nächsten Dreh 🎢"},
+ {label:"🎰 Beinahe Jackpot", value:1, question:"Die Menge tobt – doch das richtige Feld war nur einen Hauch entfernt..."},
+ {label:"🔄 Extra Dreh", value:1, question:"Der Moderator gönnt dir eine Extra-Chance 🔄"},
+ {label:"🙈 Niete", value:1, question:"Immerhin kein Totalverlust, dreh nochmal!"},
+ {label:"💦 Therme Erding", value:1, question:"Heiße Quellen bleiben heute kalt 💦"},
+ {label:"⭐ Staubsaugerbot", value:1, question:"Oh nein! Knapp am ultimativen Gewinn vorbeigeschrammt 🤖"},
  {label:"🎁 Eis-Date", value:1, question:"Happy Birthday Sammy! Dein echtes Geschenk ist ein Eis-Date 🍦🎉"}
 ];
 
@@ -150,11 +150,11 @@ arcs.append("text")
     .attr("transform",function(d,i){
        d.innerRadius=0; d.outerRadius=r;
        d.angle=(d.startAngle+d.endAngle)/2;
-       var radius=d.outerRadius-10;
-       return "rotate("+(d.angle*180/Math.PI-90)+")translate("+radius+")";
+       var radius=r*0.6;
+       return "rotate("+(d.angle*180/Math.PI-90)+")translate("+radius+")rotate(180)";
     })
-    .attr("text-anchor","end")
-    .style("font-size","12px")
+    .attr("text-anchor","middle")
+    .style("font-size","16px")
     .style("dominant-baseline","middle")
     .text(function(d,i){return data[i].label;});
 
@@ -181,17 +181,6 @@ function playTone(freq,duration){
     gain.gain.exponentialRampToValueAtTime(0.001,audioCtx.currentTime+duration);
     osc.stop(audioCtx.currentTime+duration);
 }
-var drum;
-function startDrum(){
-    if(!audioCtx||muted)return;
-    drum=audioCtx.createOscillator();
-    var g=audioCtx.createGain();
-    drum.type="square"; drum.frequency.value=100;
-    drum.connect(g); g.connect(audioCtx.destination);
-    g.gain.setValueAtTime(0.3,audioCtx.currentTime);
-    drum.start();
-}
-function stopDrum(){if(drum){drum.stop(); drum=null;}}
 function applause(){if(!audioCtx||muted)return; for(var i=0;i<5;i++){setTimeout(function(){playTone(200+Math.random()*200,0.3);},i*150);}}
 function tick(){playTone(800,0.05);}
 function ooh(){playTone(300,0.5);}
@@ -235,7 +224,6 @@ function spin(){
 
 function phase2(){
    overlay.style.display="none";
-   startDrum();
    var ps=360/data.length;
    var picked2=TROST_INDEX;
    var turns2=4+Math.floor(Math.random()*3);
@@ -247,7 +235,6 @@ function phase2(){
        .each("start",function(){tickTimer=setInterval(tick,60);})
        .each("end",function(){
            clearInterval(tickTimer);
-           stopDrum();
            oldrotation=rotation;
            d3.select("#question h1").text(data[picked2].question);
            try{confetti({particleCount:150,spread:70,origin:{y:0.6}});}catch(e){}

--- a/index.html
+++ b/index.html
@@ -146,19 +146,26 @@ arcs.append("path")
     .attr("fill",function(d,i){return color(i);})
     .attr("d",arc);
 
-arcs.append("text")
-    .attr("transform",function(d,i){
-       d.innerRadius=0; d.outerRadius=r;
-       d.angle=(d.startAngle+d.endAngle)/2;
-       var radius=r*0.6;
-       var angle=d.angle*180/Math.PI-90;
-       var flip=(angle>-90 && angle<90)?180:0;
-       return "rotate("+angle+")translate("+radius+")rotate("+flip+")";
-    })
-    .attr("text-anchor","middle")
-    .style("font-size","16px")
-    .style("dominant-baseline","middle")
-    .text(function(d,i){return data[i].label;});
+ arcs.append("text")
+     .attr("text-anchor","middle")
+     .style("font-size","16px")
+     .style("dominant-baseline","middle")
+     .text(function(d,i){return data[i].label;});
+
+ function positionLabels(){
+     arcs.selectAll("text")
+         .attr("transform",function(d){
+             d.innerRadius=0; d.outerRadius=r;
+             d.angle=(d.startAngle+d.endAngle)/2;
+             var radius=r*0.6;
+             var angle=d.angle*180/Math.PI-90;
+             var orient=(angle+rotation+360)%360;
+             var flip=(orient>90 && orient<270)?180:0;
+             return "rotate("+angle+")translate("+radius+")rotate("+flip+")";
+         });
+ }
+
+ positionLabels();
 
 svg.append("g")
    .attr("transform","translate("+(w+padding.left)+","+(h/2+padding.top)+")")
@@ -215,9 +222,10 @@ function spin(){
        .each("start",function(){tickTimer=setInterval(tick,60);})
        .each("end",function(){
            clearInterval(tickTimer);
-           oldrotation=rotation;
-           d3.select("#question h1").text(data[picked1].question);
-           if(picked1===3 || picked1===4){
+            oldrotation=rotation;
+            positionLabels();
+            d3.select("#question h1").text(data[picked1].question);
+            if(picked1===3 || picked1===4){
                overlay.style.display="block";
                overlay.textContent=Math.random()>0.5?"Zweite Chance!":"Super-Spin!";
                ooh();
@@ -242,8 +250,9 @@ function phase2(){
        .each("end",function(){
            clearInterval(tickTimer);
            oldrotation=rotation;
+           positionLabels();
            d3.select("#question h1").text(data[picked2].question);
-           try{confetti({particleCount:150,spread:70,origin:{y:0.6}});}catch(e){}
+            try{confetti({particleCount:150,spread:70,origin:{y:0.6}});}catch(e){}
            applause();
            spinBtn.remove();
        });


### PR DESCRIPTION
## Summary
- Allow page scrolling and wrap question text for better readability
- Keep wheel labels within bounds with smaller font
- Remove gift button and hide spin button when the wheel lands on the consolation prize

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68a0b77cb9b883238ed70929370da1f6